### PR TITLE
Fixing commit string and remove obsolete Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,6 @@ LIBPATHS := $(foreach dir,$(LIBDIRS),-L$(dir)/lib) \
 
 APP_ICON := $(CURDIR)/$(ICON)
 
-_3DSXFLAGS += --smdh=$(CURDIR)/$(TARGET).smdh
-
 # Compiler flags
 
 ARCH     := -march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
@@ -67,8 +65,7 @@ ZIPNAME   = lumaupdater-$(shell git describe --tags | tr -d 'v').zip
 
 # Shortcuts
 
-all : prereq $(OUTPUT).3dsx $(OUTPUT).cia
-3dsx: prereq $(OUTPUT).3dsx
+all : prereq $(OUTPUT).cia
 cia : prereq $(OUTPUT).cia
 pkg : prereq $(ZIPNAME)
 
@@ -78,15 +75,14 @@ prereq:
 
 clean:
 	@echo clean ...
-	@rm -fr $(BUILD) $(TARGET).3dsx $(OUTPUT).cia $(OUTPUT).smdh $(TARGET).elf
+	@rm -fr $(BUILD) $(OUTPUT).cia $(TARGET).elf
 
 # Archive
 
-$(ZIPNAME): $(OUTPUT).cia $(OUTPUT).3dsx $(OUTPUT).smdh
+$(ZIPNAME): $(OUTPUT).cia
 	mkdir -p $(CURDIR)/archive/3DS/lumaupdater
 	cp $(CURDIR)/lumaupdater.cfg $(CURDIR)/archive
 	cp $(OUTPUT).cia $(CURDIR)/archive
-	cp $(OUTPUT).3dsx $(OUTPUT).smdh $(CURDIR)/archive/3DS/lumaupdater
 	@(cd archive; zip -r -9 ../$(ZIPNAME) .)
 	rm -rf $(CURDIR)/archive
 	@echo
@@ -97,8 +93,6 @@ $(ZIPNAME): $(OUTPUT).cia $(OUTPUT).3dsx $(OUTPUT).smdh
 MAKEROM ?= makerom
 
 $(OUTPUT).elf: $(OFILES)
-
-$(OUTPUT).3dsx: $(OUTPUT).elf $(OUTPUT).smdh
 
 $(OUTPUT).cia: $(OUTPUT).elf $(BUILD)/banner.bnr $(BUILD)/icon.icn
 	$(MAKEROM) -f cia -o $@ -elf $< -rsf $(CURDIR)/rominfo.rsf -target t -exefslogo -logo meta/logo.bcma.lz -banner $(BUILD)/banner.bnr -icon $(BUILD)/icon.icn -DAPP_TITLE="$(APP_TITLE)" -DPRODUCT_CODE="$(PRODUCT_CODE)" -DUNIQUE_ID="$(UNIQUE_ID)"

--- a/source/version.cpp
+++ b/source/version.cpp
@@ -4,6 +4,15 @@
 #include <iostream>
 #include <string>
 
+std::string getCommit(std::string commitString) {
+	std::string commit = "";
+	for (int i = 0; i < 7; i++)
+	{
+		commit += commitString[i];
+	}
+	return commit;
+}
+
 const std::string LumaVersion::toString(bool printBranch) const {
 	std::string currentVersionStr = release;
 	if (!commit.empty()) {
@@ -11,15 +20,12 @@ const std::string LumaVersion::toString(bool printBranch) const {
 		//commit.resize(commit.size()-1);
 		//commit.erase(commit.length() - 1);
 		
-		/*commit = commit[0];
+		std::string fixedCommit = getCommit(commit);
 
-		for (int i = 0; i < 7; i++)
-		{
-			commit += commit;
-		}*/
+
 		
 		//commit.substr(0, commit.size()-1);
-		currentVersionStr += "-" + commit;
+		currentVersionStr += "-" + fixedCommit;
 	}
 	/*if (printBranch && isDev) {
 		currentVersionStr += " (dev)";


### PR DESCRIPTION
Should now work. I guess. Although, I didn't see if commit is used anywhere else, if it is, tell me.

Should fix https://github.com/KunoichiZ/lumaupdate/issues/6