### PR TITLE
Block all updates from Luma3DS 7.1

### DIFF
--- a/source/main.h
+++ b/source/main.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "libs.h"
+
+#include "release.h"
+#include "version.h"
+
+/* States */
+
+enum UpdateState {
+	UpdateConfirmationScreen,
+	Updating,
+	UpdateComplete,
+	UpdateFailed,
+	Restoring,
+	RestoreComplete,
+	RestoreFailed
+};
+
+enum class ChoiceType {
+	NoChoice,
+	UpdatePayload,
+	RestoreBackup
+};
+
+enum class SelfUpdateChoice {
+	NoChoice,
+	SelfUpdate,
+	IgnoreUpdate,
+};
+
+struct UpdateChoice {
+	ChoiceType type          = ChoiceType::NoChoice;
+	ReleaseVer chosenVersion = ReleaseVer{};
+	bool       isHourly      = false;
+
+	explicit UpdateChoice(const ChoiceType type)
+		:type(type) {}
+	UpdateChoice(const ChoiceType type, const ReleaseVer& ver, const bool hourly)
+		:type(type), chosenVersion(ver), isHourly(hourly) {}
+};
+
+struct UpdateInfo {
+	// Detected options
+	LumaVersion  currentVersion;
+	LumaVersion  backupVersion;
+	bool         migrateARN     = false;
+	bool         backupExists   = false;
+
+	// Configuration options
+	PayloadType  payloadType    = PayloadType::SIGHAX;
+	std::string  payloadPath    = "/boot.firm";
+	bool         backupExisting = true;
+	bool         selfUpdate     = true;
+	bool         writeLog       = true;
+
+	// Available data
+	ReleaseInfo* stable = nullptr;
+	ReleaseInfo* hourly = nullptr;
+
+	// Chosen settings
+	UpdateChoice choice = UpdateChoice(ChoiceType::NoChoice);
+
+  ReleaseVer chosenVersion = choice.chosenVersion;
+  bool isHourly = choice.isHourly;
+};
+
+struct PromptStatus {
+	// Redraw queries
+	bool redrawTop = false;
+	bool redrawBottom = false;
+	bool partialredraw = false;
+	bool redrawRequired() { return redrawTop || redrawBottom || partialredraw; }
+	void resetRedraw() { redrawTop = redrawBottom = partialredraw = false; }
+
+	// Selection and paging
+	int  selected = 0;
+	int  currentPage = 0;
+	int  pageCount = 0;
+
+	// Prompt choice taken?
+	bool optionChosen = false;
+};

--- a/source/update.h
+++ b/source/update.h
@@ -2,23 +2,15 @@
 
 #include "libs.h"
 
+#include "main.h"
 #include "release.h"
 
 #define MAXPATHLEN 37
-
-struct UpdateArgs {
-	PayloadType  payloadType;    /*!< Type of payload to upgrade  */
-	std::string  payloadPath;    /*!< Path to Luma3DS payload     */
-	bool         backupExisting; /*!< Backup existing payload     */
-	bool         migrateARN;     /*!< Migrate from AuReiNand      */
-	ReleaseVer   chosenVersion;  /*!< Version to update to        */
-	bool         isHourly;       /*!< Is chosen version a hourly? */
-};
 
 struct UpdateResult {
 	bool        success; /*!< Wether the operation was a success */
 	std::string errcode; /*!< Error code if success is false     */
 };
 
-UpdateResult update(const UpdateArgs& args);
-UpdateResult restore(const UpdateArgs& args);
+UpdateResult update(const UpdateInfo& args);
+UpdateResult restore(const UpdateInfo& args);


### PR DESCRIPTION
Sorry for the late updates, other commitments got in the way.

This series of commits blocks all updates from version 7.1, which is only compatible with b9s 1.0/1.1. Later versions of Luma3DS (>=8.0) will not boot on b9s 1.0/1.1 consoles.

Also contains some reshuffling of code that (hopefully) should be cleaned up in future.