### PR TITLE
Update location header capitalisation

### DIFF
--- a/source/http.cpp
+++ b/source/http.cpp
@@ -21,7 +21,7 @@ void httpGet(const char* url, u8** buf, u32* size, const bool verbose, HTTPRespo
 		// Handle 3xx codes
 		if (statuscode >= 300 && statuscode < 400) {
 			char newUrl[1024];
-			CHECK(httpc.GetResponseHeader(&context, (char*)"location", newUrl, 1024), "Could not get Location header for 3xx reply");
+			CHECK(httpc.GetResponseHeader(&context, (char*)"Location", newUrl, 1024), "Could not get Location header for 3xx reply");
 			CHECK(httpc.CloseContext(&context), "Could not close HTTP context");
 			httpGet(newUrl, buf, size, verbose, info);
 			return;


### PR DESCRIPTION
Resolves issue where the tool is unable to pick up the location header due to the location response header no longer being fully lowercase.
Concerns #82.